### PR TITLE
Reduced the number of channels between service and process

### DIFF
--- a/src/lava/magma/compiler/builder.py
+++ b/src/lava/magma/compiler/builder.py
@@ -188,7 +188,6 @@ class PyProcessBuilder(AbstractProcessBuilder):
 
         Any Py{In/Out/Ref}Ports must be strict sub-types of Py{In/Out/Ref}Ports.
         """
-
         for name, port_init in self.py_ports.items():
             lt = self._get_lava_type(name)
             if not isinstance(lt.cls, type):
@@ -421,22 +420,13 @@ class PyProcessBuilder(AbstractProcessBuilder):
             setattr(pm, name, port)
 
         for port in self.csp_rs_recv_port.values():
-            if "service_to_process_cmd" in port.name:
-                pm.service_to_process_cmd = port
-                continue
-            if "service_to_process_req" in port.name:
-                pm.service_to_process_req = port
-                continue
-            if "service_to_process_data" in port.name:
-                pm.service_to_process_data = port
+            if "service_to_process" in port.name:
+                pm.service_to_process = port
                 continue
 
         for port in self.csp_rs_send_port.values():
-            if "process_to_service_ack" in port.name:
-                pm.process_to_service_ack = port
-                continue
-            if "process_to_service_data" in port.name:
-                pm.process_to_service_data = port
+            if "process_to_service" in port.name:
+                pm.process_to_service = port
                 continue
 
         # Initialize Vars
@@ -535,18 +525,12 @@ class RuntimeServiceBuilder(AbstractRuntimeServiceBuilder):
         rs.model_ids = self._model_ids
 
         for port in self.csp_proc_send_port.values():
-            if "service_to_process_cmd" in port.name:
-                rs.service_to_process_cmd.append(port)
-            if "service_to_process_req" in port.name:
-                rs.service_to_process_req.append(port)
-            if "service_to_process_data" in port.name:
-                rs.service_to_process_data.append(port)
+            if "service_to_process" in port.name:
+                rs.service_to_process.append(port)
 
         for port in self.csp_proc_recv_port.values():
-            if "process_to_service_ack" in port.name:
-                rs.process_to_service_ack.append(port)
-            if "process_to_service_data" in port.name:
-                rs.process_to_service_data.append(port)
+            if "process_to_service" in port.name:
+                rs.process_to_service.append(port)
 
         for port in self.csp_send_port.values():
             if "service_to_runtime_ack" in port.name:

--- a/src/lava/magma/compiler/compiler.py
+++ b/src/lava/magma/compiler/compiler.py
@@ -768,50 +768,23 @@ class Compiler:
             sync_channel_builders.append(runtime_to_service_data)
 
             for process in sync_domain.processes:
-                service_to_process_cmd = \
+                service_to_process = \
                     ServiceChannelBuilderMp(ChannelType.PyPy,
                                             rsb[sync_domain],
                                             process,
                                             self._create_mgmt_port_initializer(
-                                                f"service_to_process_cmd_"
+                                                f"service_to_process_"
                                                 f"{process.id}"))
-                sync_channel_builders.append(service_to_process_cmd)
+                sync_channel_builders.append(service_to_process)
 
-                process_to_service_ack = \
+                process_to_service = \
                     ServiceChannelBuilderMp(ChannelType.PyPy,
                                             process,
                                             rsb[sync_domain],
                                             self._create_mgmt_port_initializer(
-                                                f"process_to_service_ack_"
+                                                f"process_to_service_"
                                                 f"{process.id}"))
-                sync_channel_builders.append(process_to_service_ack)
-
-                service_to_process_req = \
-                    ServiceChannelBuilderMp(ChannelType.PyPy,
-                                            rsb[sync_domain],
-                                            process,
-                                            self._create_mgmt_port_initializer(
-                                                f"service_to_process_req_"
-                                                f"{process.id}"))
-                sync_channel_builders.append(service_to_process_req)
-
-                process_to_service_data = \
-                    ServiceChannelBuilderMp(ChannelType.PyPy,
-                                            process,
-                                            rsb[sync_domain],
-                                            self._create_mgmt_port_initializer(
-                                                f"process_to_service_data_"
-                                                f"{process.id}"))
-                sync_channel_builders.append(process_to_service_data)
-
-                service_to_process_data = \
-                    ServiceChannelBuilderMp(ChannelType.PyPy,
-                                            rsb[sync_domain],
-                                            process,
-                                            self._create_mgmt_port_initializer(
-                                                f"service_to_process_data_"
-                                                f"{process.id}"))
-                sync_channel_builders.append(service_to_process_data)
+                sync_channel_builders.append(process_to_service)
         return sync_channel_builders
 
     def _create_exec_vars(self,

--- a/src/lava/magma/core/model/py/model.py
+++ b/src/lava/magma/core/model/py/model.py
@@ -6,7 +6,7 @@ from abc import ABC, abstractmethod
 
 import numpy as np
 
-from lava.magma.compiler.channels.pypychannel import CspSendPort, CspRecvPort,\
+from lava.magma.compiler.channels.pypychannel import CspSendPort, CspRecvPort, \
     CspSelector
 from lava.magma.core.model.model import AbstractProcessModel
 from lava.magma.core.model.py.ports import AbstractPyPort, PyVarPort
@@ -14,8 +14,7 @@ from lava.magma.runtime.mgmt_token_enums import (
     enum_to_np,
     enum_equal,
     MGMT_COMMAND,
-    MGMT_RESPONSE, REQ_TYPE,
-)
+    MGMT_RESPONSE, )
 
 
 class AbstractPyProcessModel(AbstractProcessModel, ABC):
@@ -33,11 +32,8 @@ class AbstractPyProcessModel(AbstractProcessModel, ABC):
     def __init__(self):
         super().__init__()
         self.model_id: ty.Optional[int] = None
-        self.service_to_process_cmd: ty.Optional[CspRecvPort] = None
-        self.process_to_service_ack: ty.Optional[CspSendPort] = None
-        self.service_to_process_req: ty.Optional[CspRecvPort] = None
-        self.process_to_service_data: ty.Optional[CspSendPort] = None
-        self.service_to_process_data: ty.Optional[CspRecvPort] = None
+        self.service_to_process: ty.Optional[CspRecvPort] = None
+        self.process_to_service: ty.Optional[CspSendPort] = None
         self.py_ports: ty.List[AbstractPyPort] = []
         self.var_ports: ty.List[PyVarPort] = []
         self.var_id_to_var_map: ty.Dict[int, ty.Any] = {}
@@ -52,11 +48,8 @@ class AbstractPyProcessModel(AbstractProcessModel, ABC):
                 self.var_ports.append(value)
 
     def start(self):
-        self.service_to_process_cmd.start()
-        self.process_to_service_ack.start()
-        self.service_to_process_req.start()
-        self.process_to_service_data.start()
-        self.service_to_process_data.start()
+        self.service_to_process.start()
+        self.process_to_service.start()
         for p in self.py_ports:
             p.start()
         self.run()
@@ -66,11 +59,8 @@ class AbstractPyProcessModel(AbstractProcessModel, ABC):
         pass
 
     def join(self):
-        self.service_to_process_cmd.join()
-        self.process_to_service_ack.join()
-        self.service_to_process_req.join()
-        self.process_to_service_data.join()
-        self.service_to_process_data.join()
+        self.service_to_process.join()
+        self.process_to_service.join()
         for p in self.py_ports:
             p.join()
 
@@ -113,96 +103,94 @@ class PyLoihiProcessModel(AbstractPyProcessModel):
         """Retrieves commands from the runtime service to iterate through the
         phases of Loihi and calls their corresponding methods of the
         ProcessModels. The phase is retrieved from runtime service
-        (service_to_process_cmd). After calling the method of a phase of all
+        (service_to_process). After calling the method of a phase of all
         ProcessModels the runtime service is informed about completion. The
         loop ends when the STOP command is received."""
         selector = CspSelector()
         action = 'cmd'
+        phase = PyLoihiProcessModel.Phase.SPK
         while True:
             if action == 'cmd':
-                phase = self.service_to_process_cmd.recv()
-                if enum_equal(phase, MGMT_COMMAND.STOP):
-                    self.process_to_service_ack.send(MGMT_RESPONSE.TERMINATED)
+                cmd = self.service_to_process.recv()
+                if enum_equal(cmd, MGMT_COMMAND.STOP):
+                    self.process_to_service.send(MGMT_RESPONSE.TERMINATED)
                     self.join()
                     return
                 try:
                     # Spiking phase - increase time step
-                    if enum_equal(phase, PyLoihiProcessModel.Phase.SPK):
+                    if enum_equal(cmd, PyLoihiProcessModel.Phase.SPK):
                         self.current_ts += 1
+                        phase = PyLoihiProcessModel.Phase.SPK
                         self.run_spk()
-                        self.process_to_service_ack.send(MGMT_RESPONSE.DONE)
+                        self.process_to_service.send(MGMT_RESPONSE.DONE)
                     # Pre-management phase
-                    elif enum_equal(phase, PyLoihiProcessModel.Phase.PRE_MGMT):
+                    elif enum_equal(cmd,
+                                    PyLoihiProcessModel.Phase.PRE_MGMT):
                         # Enable via guard method
                         if self.pre_guard():
+                            phase = PyLoihiProcessModel.Phase.PRE_MGMT
                             self.run_pre_mgmt()
-                        self.process_to_service_ack.send(MGMT_RESPONSE.DONE)
+                        self.process_to_service.send(MGMT_RESPONSE.DONE)
                     # Learning phase
-                    elif enum_equal(phase, PyLoihiProcessModel.Phase.LRN):
+                    elif enum_equal(cmd, PyLoihiProcessModel.Phase.LRN):
                         # Enable via guard method
                         if self.lrn_guard():
+                            phase = PyLoihiProcessModel.Phase.LRN
                             self.run_lrn()
-                        self.process_to_service_ack.send(MGMT_RESPONSE.DONE)
+                        self.process_to_service.send(MGMT_RESPONSE.DONE)
                     # Post-management phase
-                    elif enum_equal(phase, PyLoihiProcessModel.Phase.POST_MGMT):
+                    elif enum_equal(cmd,
+                                    PyLoihiProcessModel.Phase.POST_MGMT):
                         # Enable via guard method
                         if self.post_guard():
+                            phase = PyLoihiProcessModel.Phase.POST_MGMT
                             self.run_post_mgmt()
-                        self.process_to_service_ack.send(MGMT_RESPONSE.DONE)
+                        self.process_to_service.send(MGMT_RESPONSE.DONE)
                     # Host phase - called at the last time step before STOP
-                    elif enum_equal(phase, PyLoihiProcessModel.Phase.HOST):
+                    elif enum_equal(cmd, PyLoihiProcessModel.Phase.HOST):
+                        phase = PyLoihiProcessModel.Phase.HOST
                         pass
+                    elif enum_equal(cmd, MGMT_COMMAND.GET_DATA) and \
+                            enum_equal(phase, PyLoihiProcessModel.Phase.HOST):
+                        # Handle get/set Var requests from runtime service
+                        self._handle_get_var()
+                    elif enum_equal(cmd,
+                                    MGMT_COMMAND.SET_DATA) and enum_equal(phase,
+                                                                          PyLoihiProcessModel.Phase.HOST):
+                        # Handle get/set Var requests from runtime service
+                        self._handle_set_var()
                     else:
-                        raise ValueError(f"Wrong Phase Info Received : {phase}")
+                        raise ValueError(
+                            f"Wrong Phase Info Received : {cmd}")
                 except Exception as inst:
+                    print("Exception happened")
                     # Inform runtime service about termination
-                    self.process_to_service_ack.send(MGMT_RESPONSE.ERROR)
+                    self.process_to_service.send(MGMT_RESPONSE.ERROR)
                     self.join()
                     raise inst
-
-            elif action == 'req':
-                # Handle get/set Var requests from runtime service
-                self._handle_get_set_var()
             else:
                 # Handle VarPort requests from RefPorts
+                print("Got refport request")
                 self._handle_var_port(action)
 
-            channel_actions = [(self.service_to_process_cmd, lambda: 'cmd')]
+            channel_actions = [(self.service_to_process, lambda: 'cmd')]
             if enum_equal(phase, PyLoihiProcessModel.Phase.PRE_MGMT) or \
                     enum_equal(phase, PyLoihiProcessModel.Phase.POST_MGMT):
                 for var_port in self.var_ports:
                     for csp_port in var_port.csp_ports:
                         if isinstance(csp_port, CspRecvPort):
                             channel_actions.append((csp_port, lambda: var_port))
-            elif enum_equal(phase, PyLoihiProcessModel.Phase.HOST):
-                channel_actions.append((self.service_to_process_req,
-                                        lambda: 'req'))
             action = selector.select(*channel_actions)
-
-    # FIXME: (PP) might not be able to perform get/set during pause
-    def _handle_get_set_var(self):
-        """Handles all get/set Var requests from the runtime service and calls
-        the corresponding handling methods. The loop ends upon a
-        new command from runtime service after all get/set Var requests have
-        been handled."""
-        # Get the type of the request
-        request = self.service_to_process_req.recv()
-        if enum_equal(request, REQ_TYPE.GET):
-            self._handle_get_var()
-        elif enum_equal(request, REQ_TYPE.SET):
-            self._handle_set_var()
-        else:
-            raise RuntimeError(f"Unknown request type {request}")
 
     def _handle_get_var(self):
         """Handles the get Var command from runtime service."""
         # 1. Receive Var ID and retrieve the Var
-        var_id = self.service_to_process_req.recv()[0].item()
+        var_id = int(self.service_to_process.recv()[0].item())
         var_name = self.var_id_to_var_map[var_id]
         var = getattr(self, var_name)
 
         # 2. Send Var data
-        data_port = self.process_to_service_data
+        data_port = self.process_to_service
         # Header corresponds to number of values
         # Data is either send once (for int) or one by one (array)
         if isinstance(var, int) or isinstance(var, np.integer):
@@ -219,12 +207,12 @@ class PyLoihiProcessModel(AbstractPyProcessModel):
     def _handle_set_var(self):
         """Handles the set Var command from runtime service."""
         # 1. Receive Var ID and retrieve the Var
-        var_id = self.service_to_process_req.recv()[0].item()
+        var_id = int(self.service_to_process.recv()[0].item())
         var_name = self.var_id_to_var_map[var_id]
         var = getattr(self, var_name)
 
         # 2. Receive Var data
-        data_port = self.service_to_process_data
+        data_port = self.service_to_process
         if isinstance(var, int) or isinstance(var, np.integer):
             # First item is number of items (1) - not needed
             data_port.recv()

--- a/src/lava/magma/core/model/py/model.py
+++ b/src/lava/magma/core/model/py/model.py
@@ -127,23 +127,23 @@ class PyLoihiProcessModel(AbstractPyProcessModel):
                     elif enum_equal(cmd,
                                     PyLoihiProcessModel.Phase.PRE_MGMT):
                         # Enable via guard method
+                        phase = PyLoihiProcessModel.Phase.PRE_MGMT
                         if self.pre_guard():
-                            phase = PyLoihiProcessModel.Phase.PRE_MGMT
                             self.run_pre_mgmt()
                         self.process_to_service.send(MGMT_RESPONSE.DONE)
                     # Learning phase
                     elif enum_equal(cmd, PyLoihiProcessModel.Phase.LRN):
                         # Enable via guard method
+                        phase = PyLoihiProcessModel.Phase.LRN
                         if self.lrn_guard():
-                            phase = PyLoihiProcessModel.Phase.LRN
                             self.run_lrn()
                         self.process_to_service.send(MGMT_RESPONSE.DONE)
                     # Post-management phase
                     elif enum_equal(cmd,
                                     PyLoihiProcessModel.Phase.POST_MGMT):
                         # Enable via guard method
+                        phase = PyLoihiProcessModel.Phase.POST_MGMT
                         if self.post_guard():
-                            phase = PyLoihiProcessModel.Phase.POST_MGMT
                             self.run_post_mgmt()
                         self.process_to_service.send(MGMT_RESPONSE.DONE)
                     # Host phase - called at the last time step before STOP
@@ -170,7 +170,6 @@ class PyLoihiProcessModel(AbstractPyProcessModel):
                     raise inst
             else:
                 # Handle VarPort requests from RefPorts
-                print("Got refport request")
                 self._handle_var_port(action)
 
             channel_actions = [(self.service_to_process, lambda: 'cmd')]

--- a/src/lava/magma/core/process/process.py
+++ b/src/lava/magma/core/process/process.py
@@ -4,17 +4,16 @@
 import typing as ty
 from _collections import OrderedDict
 
+from lava.magma.compiler.executable import Executable
+from lava.magma.core.process.interfaces import \
+    AbstractProcessMember, IdGeneratorSingleton
 from lava.magma.core.process.message_interface_enum import ActorType
-from lava.magma.core.run_conditions import AbstractRunCondition
-from lava.magma.core.run_configs import RunConfig
 from lava.magma.core.process.ports.ports import \
     InPort, OutPort, RefPort, VarPort
 from lava.magma.core.process.variable import Var
-from lava.magma.core.process.interfaces import \
-    AbstractProcessMember, IdGeneratorSingleton
-from lava.magma.compiler.executable import Executable
+from lava.magma.core.run_conditions import AbstractRunCondition
+from lava.magma.core.run_configs import RunConfig
 from lava.magma.runtime.runtime import Runtime
-
 
 # Abbreviation for type annotation in Collection class
 mem_type = ty.Union[InPort, OutPort, RefPort, VarPort, Var, "AbstractProcess"]
@@ -358,7 +357,8 @@ class AbstractProcess(metaclass=ProcessPostInitCaller):
 
     # TODO: (PP) Remove  if condition on blocking as soon as non-blocking
     #  execution is completely implemented
-    def run(self, condition: AbstractRunCondition, run_cfg: RunConfig):
+    def run(self, condition: AbstractRunCondition = None, run_cfg:
+    RunConfig = None):
         """Runs process given RunConfig and RunCondition.
 
         run(..) compiles this and any process connected to this process
@@ -393,7 +393,7 @@ class AbstractProcess(metaclass=ProcessPostInitCaller):
 
         if not self._runtime:
             executable = self.compile(run_cfg)
-            self._runtime = Runtime(condition,
+            self._runtime = Runtime(
                                     executable,
                                     ActorType.MultiProcessing)
             self._runtime.initialize()

--- a/src/lava/magma/runtime/mgmt_token_enums.py
+++ b/src/lava/magma/runtime/mgmt_token_enums.py
@@ -1,12 +1,13 @@
 # Copyright (C) 2021 Intel Corporation
 # SPDX-License-Identifier: BSD-3-Clause
 # See: https://spdx.org/licenses/
-import numpy as np
 import typing as ty
+
+import numpy as np
 
 
 def enum_to_np(value: ty.Union[int, float],
-               d_type: type = np.int32) -> np.array:
+               d_type: type = np.float64) -> np.array:
     """
     Helper function to convert an int (or EnumInt) or a float to a single value
     np array so as to pass it via the message passing framework. The dtype of
@@ -45,16 +46,10 @@ class MGMT_COMMAND:
     """Signifies a STOP command from one actor to another"""
     PAUSE = enum_to_np(-2)
     """Signifies a PAUSE command from one actor to another"""
-
-
-class REQ_TYPE:
-    """
-    Signifies type of request
-    """
-    GET = enum_to_np(0)
-    """Read a variable"""
-    SET = enum_to_np(1)
-    """Write to a variable"""
+    GET_DATA = enum_to_np(-3)
+    """Signifies Read a variable"""
+    SET_DATA = enum_to_np(-4)
+    """Signifies Write a variable"""
 
 
 class MGMT_RESPONSE:

--- a/tests/lava/magma/runtime/test_get_set_var.py
+++ b/tests/lava/magma/runtime/test_get_set_var.py
@@ -92,7 +92,6 @@ class TestGetSetVar(unittest.TestCase):
                               expected_result_u)
         assert np.array_equal(process._runtime.get_var(process.v.id),
                               expected_result_v)
-        self.assertEqual(process.runtime.global_time, 15)
         process.stop()
 
     def test_get_set_var_using_var_api(self):
@@ -129,7 +128,6 @@ class TestGetSetVar(unittest.TestCase):
         process.run(condition=RunSteps(num_steps=5), run_cfg=run_config)
         assert np.array_equal(process.u.get(), expected_result_u)
         assert np.array_equal(process.v.get(), expected_result_v)
-        self.assertEqual(process.runtime.global_time, 15)
         process.stop()
 
 

--- a/tests/lava/magma/runtime/test_loihi_protocol.py
+++ b/tests/lava/magma/runtime/test_loihi_protocol.py
@@ -59,7 +59,6 @@ class TestProcess(unittest.TestCase):
         run_config = SimpleRunConfig(sync_domains=[simple_sync_domain])
         process.run(condition=RunSteps(num_steps=10), run_cfg=run_config)
         process.run(condition=RunSteps(num_steps=5), run_cfg=run_config)
-        self.assertEqual(process.runtime.global_time, 15)
         process.stop()
 
 

--- a/tests/lava/magma/runtime/test_runtime.py
+++ b/tests/lava/magma/runtime/test_runtime.py
@@ -15,7 +15,7 @@ class TestRuntime(unittest.TestCase):
         exe: Executable = Executable()
         run_cond: AbstractRunCondition = RunSteps(num_steps=10)
         mp = ActorType.MultiProcessing
-        runtime: Runtime = Runtime(run_cond=run_cond,
+        runtime: Runtime = Runtime(
                                    exe=exe,
                                    message_infrastructure_type=mp)
         expected_type: ty.Type = Runtime
@@ -28,13 +28,13 @@ class TestRuntime(unittest.TestCase):
         exec: Executable = Executable()
         run_cond: AbstractRunCondition = RunSteps(num_steps=10)
 
-        runtime1: Runtime = Runtime(run_cond, exec, ActorType.MultiProcessing)
+        runtime1: Runtime = Runtime(exec, ActorType.MultiProcessing)
         with self.assertRaises(AssertionError):
             runtime1.initialize()
 
         node: Node = Node(HeadNode, [])
         exec.node_configs.append(NodeConfig([node]))
-        runtime2: Runtime = Runtime(run_cond, exec, ActorType.MultiProcessing)
+        runtime2: Runtime = Runtime(exec, ActorType.MultiProcessing)
         runtime2.initialize()
         expected_type: ty.Type = Runtime
         assert isinstance(
@@ -43,12 +43,12 @@ class TestRuntime(unittest.TestCase):
         runtime2.stop()
 
         exec.node_configs[0].append(node)
-        runtime3: Runtime = Runtime(run_cond, exec, ActorType.MultiProcessing)
+        runtime3: Runtime = Runtime(exec, ActorType.MultiProcessing)
         with self.assertRaises(AssertionError):
             runtime3.initialize()
 
         exec.node_configs.append(NodeConfig([node]))
-        runtime4: Runtime = Runtime(run_cond, exec, ActorType.MultiProcessing)
+        runtime4: Runtime = Runtime(exec, ActorType.MultiProcessing)
         with self.assertRaises(AssertionError):
             runtime4.initialize()
 

--- a/tests/lava/magma/runtime/test_runtime_service.py
+++ b/tests/lava/magma/runtime/test_runtime_service.py
@@ -54,14 +54,11 @@ class TestRuntimeService(unittest.TestCase):
         self.assertEqual(rs.protocol, sp)
         self.assertEqual(rs.service_to_runtime_ack, None)
         self.assertEqual(rs.service_to_runtime_data, None)
-        self.assertEqual(rs.service_to_process_cmd, [])
-        self.assertEqual(rs.service_to_process_req, [])
-        self.assertEqual(rs.service_to_process_data, [])
+        self.assertEqual(rs.service_to_process, [])
         self.assertEqual(rs.runtime_to_service_cmd, None)
         self.assertEqual(rs.runtime_to_service_req, None)
         self.assertEqual(rs.runtime_to_service_data, None)
-        self.assertEqual(rs.process_to_service_ack, [])
-        self.assertEqual(rs.process_to_service_data, [])
+        self.assertEqual(rs.process_to_service, [])
 
     def test_runtime_service_start_run(self):
         pm = SimpleProcessModel()
@@ -79,27 +76,18 @@ class TestRuntimeService(unittest.TestCase):
                                                  name="service_to_runtime_data")
         runtime_to_service_data = create_channel(smm,
                                                  name="runtime_to_service_data")
-        service_to_process_cmd = [
-            create_channel(smm, name="service_to_process_cmd")]
-        process_to_service_ack = [
+        service_to_process = [
+            create_channel(smm, name="service_to_process")]
+        process_to_service = [
             create_channel(smm, name="process_to_service_ack")]
-        service_to_process_req = [
-            create_channel(smm, name="service_to_process_req")]
-        process_to_service_data = [
-            create_channel(smm, name="process_to_service_data")]
-        service_to_process_data = [
-            create_channel(smm, name="service_to_process_data")]
         runtime_to_service_cmd.dst_port.start()
         service_to_runtime_ack.src_port.start()
         runtime_to_service_req.src_port.start()
         service_to_runtime_data.dst_port.start()
         runtime_to_service_data.src_port.start()
 
-        pm.service_to_process_cmd = service_to_process_cmd[0].dst_port
-        pm.service_to_process_req = service_to_process_req[0].dst_port
-        pm.service_to_process_data = service_to_process_data[0].dst_port
-        pm.process_to_service_ack = process_to_service_ack[0].src_port
-        pm.process_to_service_data = process_to_service_data[0].src_port
+        pm.service_to_process = service_to_process[0].dst_port
+        pm.process_to_service = process_to_service[0].src_port
         pm.py_ports = []
         pm.start()
         rs.runtime_to_service_cmd = runtime_to_service_cmd.src_port
@@ -107,11 +95,8 @@ class TestRuntimeService(unittest.TestCase):
         rs.service_to_runtime_data = service_to_runtime_data.dst_port
         rs.runtime_to_service_req = runtime_to_service_req.src_port
         rs.runtime_to_service_data = runtime_to_service_data.dst_port
-        rs.service_to_process_cmd = [service_to_process_cmd[0].src_port]
-        rs.process_to_service_ack = [process_to_service_ack[0].dst_port]
-        rs.service_to_process_req = [service_to_process_req[0].src_port]
-        rs.process_to_service_data = [process_to_service_data[0].dst_port]
-        rs.service_to_process_data = [service_to_process_data[0].src_port]
+        rs.service_to_process = [service_to_process[0].src_port]
+        rs.process_to_service = [process_to_service[0].dst_port]
         rs.join()
         pm.join()
         smm.shutdown()


### PR DESCRIPTION
<!-- For questions please refer to https://lava-nc.org/developer_guide.html#how-to-contribute-to-lava or ask in a comment below -->


<!-- All pull requests require an issue https://github.com/lava-nc/lava/issues -->

<!-- Insert issue here as "Issue Number: #XXXX", example "Issue Number: #19" -->
Issue Number: Remove hacks and refactor Runtime and RuntimeService/Synchronizer #86

<!-- Insert one sentence pr objective here, can be copied from relevant issue. -->
Objective of pull request: Reduced the number of channels between service and process

## Pull request checklist

Your PR fulfills the following requirements:
- [X ] [Issue](https://github.com/lava-nc/lava/issues) created that explains the change and why it's needed
- [ ] Tests are part of the PR (for bug fixes / features)
- [ ] [Docs](https://github.com/lava-nc/docs) reviewed and added / updated if needed (for bug fixes / features)
- [X ] PR conforms to [Coding Conventions](https://lava-nc.org/developer_guide.html#coding-conventions)
- [X] [PR applys BSD 3-clause or LGPL2.1+ Licenses](https://lava-nc.org/developer_guide.html#add-a-license) to all code files
- [ ] Lint (`pyb`) passes locally
- [ ] Build tests (`pyb -E unit`) or (`python -m unittest`) passes locally


## Pull request type

<!-- Please do not submit updates to dependencies unless it fixes an issue. --> 

<!-- Please limit your pull request to one type, submit multiple pull requests if needed. --> 

Please check your PR type:
- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [X ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation changes
- [ ] Other (please describe): 


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, can be copied from relevant issue. -->
- Currently we have five channels between runtime service and process model. 
- 1. Used for sending cmd from RS to PM
- 2. Used for sending ack back from PM to RS
- 3. Used for sending READ/WRITE Req from RS to PM
- 4. Used to send write data from RS to PM
- 5. Used to send read data from PM to RS

## What is the new behavior?
<!-- Please describe the new behavior, can be copied from relevant issue. -->
- Reduces the number of channels between runtime service and process model. Also it removes the notion of time step from the runtime.
- 1. One way channel for all cmd/get-set-req/data from RS to PM
- 2. One channel for all ack/data from PM to RS

## Does this introduce a breaking change?

- [ ] Yes
- [X] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->


## Supplemental information

<!-- Any other information that is important to this PR. -->
